### PR TITLE
bump base image for dask 2.8.1

### DIFF
--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -1,2 +1,2 @@
 # Note that there must be a tag
-FROM pangeo/pangeo-notebook-onbuild:2019.11.15
+FROM pangeo/pangeo-notebook-onbuild:2019.11.25


### PR DESCRIPTION
We're seeing dask workers lingering on the aws binder. This should fix the issue.

See: https://github.com/pangeo-data/pangeo-stacks/pull/93 

@andersy005 @jhamman - please merge as soon as possible